### PR TITLE
Add suggested_key for Linux

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
     "toggle-inspector": {
       "suggested_key": {
         "windows": "Ctrl+Shift+X",
+        "linux": "Ctrl+Shift+X",
         "mac": "Command+Shift+X",
         "chromeos": "Ctrl+Shift+X"
       },


### PR DESCRIPTION
This is required in order to install the extension on Linux.